### PR TITLE
use other variable to configure log level

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,7 @@ fn main() -> anyhow::Result<()> {
 
 fn handle_opts() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_env_filter(tracing_subscriber::EnvFilter::from_env("CARGO_RR_LOG"))
         .init();
 
     let OptWrapper::Opt(opt) = OptWrapper::from_args();


### PR DESCRIPTION
The log output will break the interactive selection of `cargo rr test`. Therefore use other variable so that users that have RUST_LOG set in their development environment can still use it.